### PR TITLE
로그인 프로세스 수정

### DIFF
--- a/src/main/java/com/js/secondhandauction/common/config/PasswordConfig.java
+++ b/src/main/java/com/js/secondhandauction/common/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package com.js.secondhandauction.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
+++ b/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
@@ -18,10 +18,8 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
-    @Bean
-    PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     CustomUserDetailsService customUserDetailsService;

--- a/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
+++ b/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
@@ -1,7 +1,10 @@
 package com.js.secondhandauction.common.config;
 
+import com.js.secondhandauction.common.security.CustomAuthenticationProvider;
 import com.js.secondhandauction.common.security.handler.CustomAccessDeniedHandler;
 import com.js.secondhandauction.common.security.handler.CustomAuthenticationEntryPoint;
+import com.js.secondhandauction.common.security.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,12 +16,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-public class SpringSecurityConfig {
+public class SecurityConfig {
 
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    @Autowired
+    CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -27,8 +33,9 @@ public class SpringSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(FormLoginConfigurer::disable)
                 .logout(LogoutConfigurer::disable)
+                .userDetailsService(customUserDetailsService)
+                .authenticationProvider(customAuthenticationProvider())
                 .authorizeHttpRequests(request -> request
-                        //.dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                         .requestMatchers("/public/**").permitAll()
                         .anyRequest().authenticated()
@@ -40,4 +47,10 @@ public class SpringSecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public CustomAuthenticationProvider customAuthenticationProvider() {
+        return new CustomAuthenticationProvider();
+    }
+
 }

--- a/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
@@ -4,7 +4,7 @@ import com.js.secondhandauction.common.exception.ErrorCode;
 import com.js.secondhandauction.common.security.service.CustomUserDetails;
 import com.js.secondhandauction.core.member.domain.Member;
 import com.js.secondhandauction.core.member.exception.MemberException;
-import com.js.secondhandauction.core.member.repository.MemberRepository;
+import com.js.secondhandauction.core.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,13 +13,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class CustomAuthenticationProvider implements AuthenticationProvider {
 
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberService memberService;
     @Autowired
     private PasswordEncoder passwordEncoder;
 
@@ -27,9 +25,9 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
 
-        Optional<Member> member = memberRepository.findByUserId(principal.getUsername());
+        Member member = memberService.getMemberForLogin(principal.getUsername());
 
-        if (!passwordEncoder.matches(authentication.getCredentials().toString(), member.get().getPassword())) {
+        if (!passwordEncoder.matches(authentication.getCredentials().toString(), member.getPassword())) {
             throw new MemberException(ErrorCode.INVALID_PASSWORD);
         }
 

--- a/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package com.js.secondhandauction.common.security;
+
+import com.js.secondhandauction.common.exception.ErrorCode;
+import com.js.secondhandauction.common.security.service.CustomUserDetails;
+import com.js.secondhandauction.core.member.domain.Member;
+import com.js.secondhandauction.core.member.exception.MemberException;
+import com.js.secondhandauction.core.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+
+        Optional<Member> member = memberRepository.findByUserId(principal.getUsername());
+
+        if (!passwordEncoder.matches(authentication.getCredentials().toString(), member.get().getPassword())) {
+            throw new MemberException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        return new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return true;
+    }
+}

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
@@ -17,18 +17,17 @@ public class CustomUserDetails implements UserDetails, Serializable {
 
     private long uniqId;
     private String userId;
-    private String password;
     @Getter
     private Role role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
+        return Collections.singleton(new SimpleGrantedAuthority(role.toString()));
     }
 
     @Override
     public String getPassword() {
-        return password;
+        return null;
     }
 
     @Override
@@ -61,6 +60,6 @@ public class CustomUserDetails implements UserDetails, Serializable {
     }
 
     public static CustomUserDetails of(final Member member) {
-        return new CustomUserDetails(member.getUniqId(), member.getUserId(), member.getPassword(), member.getRole());
+        return new CustomUserDetails(member.getUniqId(), member.getUserId(), member.getRole());
     }
 }

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 @AllArgsConstructor
 public class CustomUserDetails implements UserDetails, Serializable {
 
-    private long uniqId;
+    private long userNo;
     private String userId;
     @Getter
     private Role role;
@@ -36,7 +36,7 @@ public class CustomUserDetails implements UserDetails, Serializable {
     }
 
     public long getId() {
-        return uniqId;
+        return userNo;
     }
 
     @Override
@@ -60,6 +60,6 @@ public class CustomUserDetails implements UserDetails, Serializable {
     }
 
     public static CustomUserDetails of(final Member member) {
-        return new CustomUserDetails(member.getUniqId(), member.getUserId(), member.getRole());
+        return new CustomUserDetails(member.getUserNo(), member.getUserId(), member.getRole());
     }
 }

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
@@ -1,21 +1,19 @@
 package com.js.secondhandauction.common.security.service;
 
 
-import com.js.secondhandauction.core.member.domain.Member;
 import com.js.secondhandauction.core.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Override
     public CustomUserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.js.secondhandauction.common.security.service;
 
 
-import com.js.secondhandauction.core.member.repository.MemberRepository;
+import com.js.secondhandauction.core.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberService memberService;
 
     @Override
     public CustomUserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        return CustomUserDetails.of(memberRepository.findByUserId(userId).orElseThrow(() -> new UsernameNotFoundException(userId)));
+        return CustomUserDetails.of(memberService.getMemberForLogin(userId));
     }
 }

--- a/src/main/java/com/js/secondhandauction/core/auction/service/AuctionService.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/service/AuctionService.java
@@ -83,7 +83,7 @@ public class AuctionService {
     }
 
     private void validateUser(long id, Auction auction) {
-        int userTotalBalance = memberService.getMemberByUniqId(id).getTotalBalance();
+        int userTotalBalance = memberService.getMemberByUserNo(id).getTotalBalance();
         if (userTotalBalance < auction.getBid()) {
             throw new MemberException(ErrorCode.CANNOT_TOTALBALANCE_MINUS);
         }
@@ -136,10 +136,10 @@ public class AuctionService {
 
 
     private void updateUserBalanceAndCreateAuction(Auction auction, Auction lastTick) {
-        memberService.updateMemberTotalBalanceByUniqId(auction.getRegId(), auction.getBid() * -1);
+        memberService.updateMemberTotalBalanceByUserNo(auction.getRegId(), auction.getBid() * -1);
 
         if (lastTick != null) {
-            memberService.updateMemberTotalBalanceByUniqId(lastTick.getRegId(), lastTick.getBid());
+            memberService.updateMemberTotalBalanceByUserNo(lastTick.getRegId(), lastTick.getBid());
         } else {
             itemService.updateItemIsBid(auction.getItemNo(), true);
         }
@@ -152,7 +152,7 @@ public class AuctionService {
     }
 
     private void finishAuction(Auction auction, Item item) {
-        memberService.updateMemberTotalBalanceByUniqId(item.getRegId(), auction.getBid());
+        memberService.updateMemberTotalBalanceByUserNo(item.getRegId(), auction.getBid());
 
         itemService.updateItemState(item.getItemNo(), State.SOLDOUT);
 

--- a/src/main/java/com/js/secondhandauction/core/auth/service/AuthService.java
+++ b/src/main/java/com/js/secondhandauction/core/auth/service/AuthService.java
@@ -1,35 +1,28 @@
 package com.js.secondhandauction.core.auth.service;
 
-import com.js.secondhandauction.common.exception.ErrorCode;
 import com.js.secondhandauction.common.security.service.CustomUserDetails;
-import com.js.secondhandauction.core.member.exception.MemberException;
-import com.js.secondhandauction.core.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AuthService {
     @Autowired
-    MemberRepository memberRepository;
+    AuthenticationProvider AuthenticationProvider;
 
     @Autowired
-    AuthenticationManagerBuilder managerBuilder;
+    UserDetailsService userDetailsService;
 
     public Authentication login(String userId, String password) {
-        CustomUserDetails userDetails = CustomUserDetails.of(memberRepository.findByUserId(userId).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER)));
+        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(userId);
 
         Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, password);
 
-        try {
-            // 인증 정보 반환
-            return managerBuilder.getObject().authenticate(auth);
-        } catch (AuthenticationException e) {
-            throw new MemberException(ErrorCode.INVALID_PASSWORD);
-        }
+        // 인증 정보 반환
+        return AuthenticationProvider.authenticate(auth);
     }
 
 

--- a/src/main/java/com/js/secondhandauction/core/member/domain/Member.java
+++ b/src/main/java/com/js/secondhandauction/core/member/domain/Member.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
-    private long uniqId;
+    private long userNo;
     private String userId;
     private String password;
     private String nickname;

--- a/src/main/java/com/js/secondhandauction/core/member/dto/MemberGetResponse.java
+++ b/src/main/java/com/js/secondhandauction/core/member/dto/MemberGetResponse.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberGetResponse implements Serializable {
-    private long uniqId;
+    private long userNo;
     private String userId;
     private String nickname;
     private int totalBalance;
@@ -32,7 +32,7 @@ public class MemberGetResponse implements Serializable {
 
     public static MemberGetResponse of(Member member) {
         return MemberGetResponse.builder()
-                .uniqId(member.getUniqId())
+                .userNo(member.getUserNo())
                 .userId(member.getUserId())
                 .nickname(member.getNickname())
                 .totalBalance(member.getTotalBalance())

--- a/src/main/java/com/js/secondhandauction/core/member/repository/MemberRepository.java
+++ b/src/main/java/com/js/secondhandauction/core/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ public interface MemberRepository {
 
     Optional<Member> findByUserId(String userId);
 
-    Optional<Member> findByUniqId(long id);
+    Optional<Member> findByUserNo(long id);
 
     void updateTotalBalance(String userId, int totalBalance);
 

--- a/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
+++ b/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
@@ -64,6 +64,14 @@ public class MemberService {
         return MemberGetResponse.of(member);
     }
 
+    /**
+     * 로그인을 위한 회원 조회 userid 로
+     */
+    @Cacheable(key = "#userId", value = "MEMBER_LOGIN")
+    public Member getMemberForLogin(String userId) {
+        return memberRepository.findByUserId(userId).orElseThrow(NotFoundMemberException::new);
+    }
+
 
     /**
      * 회원 가진금액 더하기 UserId 로

--- a/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
+++ b/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
@@ -56,11 +56,11 @@ public class MemberService {
     }
 
     /**
-     * 회원 조회 uniqid로
+     * 회원 조회 userNo로
      */
-    @Cacheable(key = "#id", value = "MEMBER_UNIQID")
-    public MemberGetResponse getMemberByUniqId(long id) {
-        Member member = memberRepository.findByUniqId(id).orElseThrow(NotFoundMemberException::new);
+    @Cacheable(key = "#id", value = "MEMBER_USERNO")
+    public MemberGetResponse getMemberByUserNo(long id) {
+        Member member = memberRepository.findByUserNo(id).orElseThrow(NotFoundMemberException::new);
         return MemberGetResponse.of(member);
     }
 
@@ -81,10 +81,10 @@ public class MemberService {
     }
 
     /**
-     * 회원 가진금액 더하기 uniqId로
+     * 회원 가진금액 더하기 userNo로
      */
-    public void updateMemberTotalBalanceByUniqId(long id, int totalBalance) {
-        Member member = memberRepository.findByUniqId(id).orElseThrow(NotFoundMemberException::new);
+    public void updateMemberTotalBalanceByUserNo(long id, int totalBalance) {
+        Member member = memberRepository.findByUserNo(id).orElseThrow(NotFoundMemberException::new);
 
         evictCache(member);
 
@@ -131,7 +131,7 @@ public class MemberService {
     @Caching(
             evict = {
                     @CacheEvict(key = "#member.userId", value = "MEMBER_USERID"),
-                    @CacheEvict(key = "#member.uniqId", value = "MEMBER_UNIQID")
+                    @CacheEvict(key = "#member.userNo", value = "MEMBER_USERNO")
             }
     )
     public void evictCache(Member member) {

--- a/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
+++ b/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
@@ -8,8 +8,8 @@ import com.js.secondhandauction.core.member.dto.MemberGetResponse;
 import com.js.secondhandauction.core.member.exception.NotFoundMemberException;
 import com.js.secondhandauction.core.member.exception.MemberException;
 import com.js.secondhandauction.core.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
@@ -17,13 +17,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class MemberService {
 
-    final MemberRepository memberRepository;
+    @Autowired
+    MemberRepository memberRepository;
 
-    final PasswordEncoder passwordEncoder;
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     /**
      * 회원가입

--- a/src/main/resources/mybatis-mapper/UserMapper.xml
+++ b/src/main/resources/mybatis-mapper/UserMapper.xml
@@ -5,17 +5,17 @@
 
 <mapper namespace="com.js.secondhandauction.core.member.repository.MemberRepository">
     <insert id="create" parameterType="com.js.secondhandauction.core.member.domain.Member" useGeneratedKeys="true"
-            keyProperty="uniqId" keyColumn="uniqId">
+            keyProperty="userNo" keyColumn="userNo">
     <![CDATA[
         insert into Member
-            (uniq_id, user_id, nickname, password, total_balance, role)
-        values (#{uniqId}, #{userId}, #{nickname}, #{password}, #{totalBalance}, #{role})
+            (user_id, nickname, password, total_balance, role)
+        values (#{userId}, #{nickname}, #{password}, #{totalBalance}, #{role})
         ]]>
     </insert>
 
     <select id="findByUserId">
     <![CDATA[
-        select uniq_id,
+        select user_no,
                user_id,
                password,
                nickname,
@@ -28,9 +28,9 @@
         ]]>
     </select>
 
-    <select id="findByUniqId">
+    <select id="findByUserNo">
     <![CDATA[
-        select uniq_id,
+        select user_no,
                user_id,
                password,
                nickname,
@@ -39,7 +39,7 @@
                upt_date,
                role
         from Member
-        where uniq_id = #{uniqId}
+        where user_no = #{userNo}
         ]]>
     </select>
 

--- a/src/test/java/com/js/secondhandauction/core/auction/AuctionServiceTest.java
+++ b/src/test/java/com/js/secondhandauction/core/auction/AuctionServiceTest.java
@@ -56,14 +56,14 @@ public class AuctionServiceTest {
     @BeforeEach
     public void setup() {
         member = MemberGetResponse.builder()
-                .uniqId(MEMBER_ID)
+                .userNo(MEMBER_ID)
                 .userId("Test User")
                 .nickname("Test Name")
                 .totalBalance(10000000)
                 .build();
 
         member2 = MemberGetResponse.builder()
-                .uniqId(MEMBER_ID2)
+                .userNo(MEMBER_ID2)
                 .userId("Test User")
                 .nickname("Test Name")
                 .totalBalance(10000000)
@@ -105,9 +105,9 @@ public class AuctionServiceTest {
 
         auctionRequest = new AuctionRequest(NO_TICK_ITEM_NO, 500000);
 
-        Mockito.when(memberService.getMemberByUniqId(MEMBER_ID)).thenReturn(member);
+        Mockito.when(memberService.getMemberByUserNo(MEMBER_ID)).thenReturn(member);
 
-        Mockito.when(memberService.getMemberByUniqId(MEMBER_ID2)).thenReturn(member2);
+        Mockito.when(memberService.getMemberByUserNo(MEMBER_ID2)).thenReturn(member2);
 
         //정상 입찰
         Mockito.when(auctionRepository.getCountTick(NO_TICK_ITEM_NO)).thenReturn(0);

--- a/src/test/java/com/js/secondhandauction/core/member/MemberServiceTest.java
+++ b/src/test/java/com/js/secondhandauction/core/member/MemberServiceTest.java
@@ -105,17 +105,17 @@ public class MemberServiceTest {
     @DisplayName("유저의 자금을 변경한다")
     void testUpdateTotalBalance() {
         //정상 자금 변경
-        when(memberRepository.findByUniqId(10L)).thenReturn(Optional.ofNullable(member));
+        when(memberRepository.findByUserNo(10L)).thenReturn(Optional.ofNullable(member));
 
-        memberService.updateMemberTotalBalanceByUniqId(10L, 500000);
+        memberService.updateMemberTotalBalanceByUserNo(10L, 500000);
 
         Mockito.verify(memberRepository, times(1)).updateTotalBalance(anyString(), anyInt());
 
         //사용자 자금보다 더 큰 금액을 빼려 해 변경에 실패
-        when(memberRepository.findByUniqId(10L)).thenReturn(Optional.ofNullable(member));
+        when(memberRepository.findByUserNo(10L)).thenReturn(Optional.ofNullable(member));
 
         assertThrows(MemberException.class,
-                () -> memberService.updateMemberTotalBalanceByUniqId(10L, -20000000), ErrorCode.CANNOT_TOTALBALANCE_MINUS.getMessage());
+                () -> memberService.updateMemberTotalBalanceByUserNo(10L, -20000000), ErrorCode.CANNOT_TOTALBALANCE_MINUS.getMessage());
 
     }
 


### PR DESCRIPTION
1. 로그인 후 세션에 비밀번호가 담기지 않도록 수정
2. member uniq_id user_no로 컬럼 변경
3. 로그인 시 쿼리 두번 진행하는 부분을 MemberService에 캐시를 통해 한번만 수행하도록 수정