### PR TITLE
아이템/경매 로직 수정

### DIFF
--- a/src/main/java/com/js/secondhandauction/common/config/PasswordConfig.java
+++ b/src/main/java/com/js/secondhandauction/common/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package com.js.secondhandauction.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
+++ b/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
@@ -18,10 +18,8 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
-    @Bean
-    PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     CustomUserDetailsService customUserDetailsService;

--- a/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
+++ b/src/main/java/com/js/secondhandauction/common/config/SecurityConfig.java
@@ -1,7 +1,10 @@
 package com.js.secondhandauction.common.config;
 
+import com.js.secondhandauction.common.security.CustomAuthenticationProvider;
 import com.js.secondhandauction.common.security.handler.CustomAccessDeniedHandler;
 import com.js.secondhandauction.common.security.handler.CustomAuthenticationEntryPoint;
+import com.js.secondhandauction.common.security.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,12 +16,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-public class SpringSecurityConfig {
+public class SecurityConfig {
 
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    @Autowired
+    CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -27,8 +33,9 @@ public class SpringSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(FormLoginConfigurer::disable)
                 .logout(LogoutConfigurer::disable)
+                .userDetailsService(customUserDetailsService)
+                .authenticationProvider(customAuthenticationProvider())
                 .authorizeHttpRequests(request -> request
-                        //.dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                         .requestMatchers("/public/**").permitAll()
                         .anyRequest().authenticated()
@@ -40,4 +47,10 @@ public class SpringSecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public CustomAuthenticationProvider customAuthenticationProvider() {
+        return new CustomAuthenticationProvider();
+    }
+
 }

--- a/src/main/java/com/js/secondhandauction/common/exception/ErrorCode.java
+++ b/src/main/java/com/js/secondhandauction/common/exception/ErrorCode.java
@@ -20,11 +20,9 @@ public enum ErrorCode {
     //ITEM
     NOT_FOUND_ITEM(404, "I001", "존재하지 않는 아이템입니다."),
     ALREADY_SOLDOUT(422, "I002", "이미 판매된 아이템입니다."),
-    CANNOT_UPDATE_SOLDOUT_ITEM(422, "I003", "판매된 아이템은 수정할 수 없습니다."),
+    CANNOT_CHANGE_SOLDOUT_ITEM(422, "I003", "판매된 아이템은 수정할 수 없습니다."),
+    CANNOT_CHANGE_BID_ITEM(422, "I004", "입찰된 아이템은 수정할 수 없습니다."),
     EDIT_ONLY_REGID(422, "I004", "등록자만 변경할 수 있습니다."),
-    CANNOT_UPDATE_BID_ITEM(422, "I005", "입찰중인 아이템의 등록금액을 변경할 수 없습니다."),
-    CANNOT_DELETE_SOLDOUT_ITEM(422, "M006", "판매된 아이템은 삭제할 수 없습니다."),
-    CANNOT_DELETE_BID_ITEM(422, "M007", "입찰중인 아이템은 삭제할 수 없습니다."),
 
     //AUCTION
     DUPLICATE_MEMBER_TICK(400, "A001", "같은 회원이 반복입찰할 수 없습니다."),

--- a/src/main/java/com/js/secondhandauction/common/exception/ErrorCode.java
+++ b/src/main/java/com/js/secondhandauction/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     NOT_FOUND_ITEM(404, "I001", "존재하지 않는 아이템입니다."),
     CANNOT_CHANGE_ITEM(422, "I003", "아이템을 수정할 수 없습니다."),
     EDIT_ONLY_REGID(422, "I004", "등록자만 변경할 수 있습니다."),
+    CANNOT_BID_EXPIRED(400, "A006", "경매가 종료된 상품입니다."),
 
     //AUCTION
     DUPLICATE_MEMBER_TICK(400, "A001", "같은 회원이 반복입찰할 수 없습니다."),
@@ -28,7 +29,7 @@ public enum ErrorCode {
     CANNOT_BID_MYSELF(400, "A003", "자신의 상품에는 입찰할 수 없습니다."),
     CANNOT_BETTING_OVER_MAXTIMES(400, "A004", "최대 입찰 횟수를 초과하였습니다."),
     CAN_BID_ONLY_ONSALE(400, "A005", "판매중인 상품만 입찰할 수 있습니다."),
-    CANNOT_OVER_IMMEDIATEPRICE(400, "A006", "즉시 구매가보다 높은 금액으로 입찰할 수 없습니다.");
+    CANNOT_OVER_IMMEDIATEPRICE(400, "A007", "즉시 구매가보다 높은 금액으로 입찰할 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/js/secondhandauction/common/exception/ErrorCode.java
+++ b/src/main/java/com/js/secondhandauction/common/exception/ErrorCode.java
@@ -19,14 +19,16 @@ public enum ErrorCode {
 
     //ITEM
     NOT_FOUND_ITEM(404, "I001", "존재하지 않는 아이템입니다."),
-    ALREADY_SOLDOUT(422, "I002", "이미 판매된 아이템입니다."),
-    CANNOT_CHANGE_SOLDOUT_ITEM(422, "I003", "판매된 아이템은 수정할 수 없습니다."),
-    CANNOT_CHANGE_BID_ITEM(422, "I004", "입찰된 아이템은 수정할 수 없습니다."),
+    CANNOT_CHANGE_ITEM(422, "I003", "아이템을 수정할 수 없습니다."),
     EDIT_ONLY_REGID(422, "I004", "등록자만 변경할 수 있습니다."),
 
     //AUCTION
     DUPLICATE_MEMBER_TICK(400, "A001", "같은 회원이 반복입찰할 수 없습니다."),
-    NOT_OVER_MINBID(400, "A002", "최소 입찰금액을 넘지 못했습니다.");
+    NOT_OVER_MINBID(400, "A002", "최소 입찰금액을 넘지 못했습니다."),
+    CANNOT_BID_MYSELF(400, "A003", "자신의 상품에는 입찰할 수 없습니다."),
+    CANNOT_BETTING_OVER_MAXTIMES(400, "A004", "최대 입찰 횟수를 초과하였습니다."),
+    CAN_BID_ONLY_ONSALE(400, "A005", "판매중인 상품만 입찰할 수 있습니다."),
+    CANNOT_OVER_IMMEDIATEPRICE(400, "A006", "즉시 구매가보다 높은 금액으로 입찰할 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
@@ -4,7 +4,7 @@ import com.js.secondhandauction.common.exception.ErrorCode;
 import com.js.secondhandauction.common.security.service.CustomUserDetails;
 import com.js.secondhandauction.core.member.domain.Member;
 import com.js.secondhandauction.core.member.exception.MemberException;
-import com.js.secondhandauction.core.member.repository.MemberRepository;
+import com.js.secondhandauction.core.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,13 +13,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class CustomAuthenticationProvider implements AuthenticationProvider {
 
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberService memberService;
     @Autowired
     private PasswordEncoder passwordEncoder;
 
@@ -27,9 +25,9 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
 
-        Optional<Member> member = memberRepository.findByUserId(principal.getUsername());
+        Member member = memberService.getMemberForLogin(principal.getUsername());
 
-        if (!passwordEncoder.matches(authentication.getCredentials().toString(), member.get().getPassword())) {
+        if (!passwordEncoder.matches(authentication.getCredentials().toString(), member.getPassword())) {
             throw new MemberException(ErrorCode.INVALID_PASSWORD);
         }
 

--- a/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/js/secondhandauction/common/security/CustomAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package com.js.secondhandauction.common.security;
+
+import com.js.secondhandauction.common.exception.ErrorCode;
+import com.js.secondhandauction.common.security.service.CustomUserDetails;
+import com.js.secondhandauction.core.member.domain.Member;
+import com.js.secondhandauction.core.member.exception.MemberException;
+import com.js.secondhandauction.core.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+
+        Optional<Member> member = memberRepository.findByUserId(principal.getUsername());
+
+        if (!passwordEncoder.matches(authentication.getCredentials().toString(), member.get().getPassword())) {
+            throw new MemberException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        return new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return true;
+    }
+}

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
@@ -17,18 +17,17 @@ public class CustomUserDetails implements UserDetails, Serializable {
 
     private long uniqId;
     private String userId;
-    private String password;
     @Getter
     private Role role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
+        return Collections.singleton(new SimpleGrantedAuthority(role.toString()));
     }
 
     @Override
     public String getPassword() {
-        return password;
+        return null;
     }
 
     @Override
@@ -61,6 +60,6 @@ public class CustomUserDetails implements UserDetails, Serializable {
     }
 
     public static CustomUserDetails of(final Member member) {
-        return new CustomUserDetails(member.getUniqId(), member.getUserId(), member.getPassword(), member.getRole());
+        return new CustomUserDetails(member.getUniqId(), member.getUserId(), member.getRole());
     }
 }

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 @AllArgsConstructor
 public class CustomUserDetails implements UserDetails, Serializable {
 
-    private long uniqId;
+    private long userNo;
     private String userId;
     @Getter
     private Role role;
@@ -36,7 +36,7 @@ public class CustomUserDetails implements UserDetails, Serializable {
     }
 
     public long getId() {
-        return uniqId;
+        return userNo;
     }
 
     @Override
@@ -60,6 +60,6 @@ public class CustomUserDetails implements UserDetails, Serializable {
     }
 
     public static CustomUserDetails of(final Member member) {
-        return new CustomUserDetails(member.getUniqId(), member.getUserId(), member.getRole());
+        return new CustomUserDetails(member.getUserNo(), member.getUserId(), member.getRole());
     }
 }

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetails.java
@@ -3,6 +3,7 @@ package com.js.secondhandauction.common.security.service;
 import com.js.secondhandauction.core.member.domain.Member;
 import com.js.secondhandauction.core.member.domain.Role;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -13,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 @AllArgsConstructor
+@Builder
 public class CustomUserDetails implements UserDetails, Serializable {
 
     private long userNo;

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
@@ -1,21 +1,19 @@
 package com.js.secondhandauction.common.security.service;
 
 
-import com.js.secondhandauction.core.member.domain.Member;
 import com.js.secondhandauction.core.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Override
     public CustomUserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {

--- a/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/js/secondhandauction/common/security/service/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.js.secondhandauction.common.security.service;
 
 
-import com.js.secondhandauction.core.member.repository.MemberRepository;
+import com.js.secondhandauction.core.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberService memberService;
 
     @Override
     public CustomUserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        return CustomUserDetails.of(memberRepository.findByUserId(userId).orElseThrow(() -> new UsernameNotFoundException(userId)));
+        return CustomUserDetails.of(memberService.getMemberForLogin(userId));
     }
 }

--- a/src/main/java/com/js/secondhandauction/core/auction/controller/AuctionController.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/controller/AuctionController.java
@@ -3,10 +3,10 @@ package com.js.secondhandauction.core.auction.controller;
 import com.js.secondhandauction.common.response.ApiResponse;
 import com.js.secondhandauction.common.security.service.CustomUserDetails;
 import com.js.secondhandauction.core.auction.domain.Auction;
+import com.js.secondhandauction.core.auction.dto.AuctionImmediatePurchaseRequest;
 import com.js.secondhandauction.core.auction.dto.AuctionRequest;
 import com.js.secondhandauction.core.auction.dto.AuctionResponse;
 import com.js.secondhandauction.core.auction.service.AuctionService;
-import com.js.secondhandauction.core.member.domain.Member;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,12 +24,18 @@ public class AuctionController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<AuctionResponse>> createAuction(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody AuctionRequest auctionRequest) {
-        final long id = customUserDetails.getId();
-        return new ResponseEntity<>(ApiResponse.success(auctionService.createAuction(id, auctionRequest)), HttpStatus.CREATED);
+        return new ResponseEntity<>(ApiResponse.success(auctionService.createAuction(customUserDetails, auctionRequest)), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/immediate-purchase")
+    public ResponseEntity<ApiResponse<AuctionResponse>> immediatePurchaseItem(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody AuctionImmediatePurchaseRequest auctionImmediatePurchaseRequest) {
+        return new ResponseEntity<>(ApiResponse.success(auctionService.createImmediateAuction(customUserDetails, auctionImmediatePurchaseRequest)), HttpStatus.CREATED);
     }
 
     @GetMapping("/{itemNo}")
     public ResponseEntity<ApiResponse<List<Auction>>> getAuctions(@PathVariable("itemNo") long itemNo) {
         return new ResponseEntity<>(ApiResponse.success(auctionService.getAuctions(itemNo)), HttpStatus.OK);
     }
+
+
 }

--- a/src/main/java/com/js/secondhandauction/core/auction/dto/AuctionImmediatePurchaseRequest.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/dto/AuctionImmediatePurchaseRequest.java
@@ -3,14 +3,12 @@ package com.js.secondhandauction.core.auction.dto;
 import com.js.secondhandauction.common.security.service.CustomUserDetails;
 import com.js.secondhandauction.core.auction.domain.Auction;
 
-public record AuctionRequest(
-        long itemNo,
-        int bid
+public record AuctionImmediatePurchaseRequest(
+        long itemNo
 ) {
     public Auction toEntity(CustomUserDetails customUserDetails) {
         return Auction.builder()
                 .itemNo(itemNo)
-                .bid(bid)
                 .regId(customUserDetails.getId())
                 .build();
     }

--- a/src/main/java/com/js/secondhandauction/core/auction/dto/AuctionLastBidResponse.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/dto/AuctionLastBidResponse.java
@@ -1,0 +1,13 @@
+package com.js.secondhandauction.core.auction.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuctionLastBidResponse {
+    private long itemNo;
+    private int bid;
+    private long regId;
+}

--- a/src/main/java/com/js/secondhandauction/core/auction/exception/DuplicateUserTickException.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/exception/DuplicateUserTickException.java
@@ -1,9 +1,0 @@
-package com.js.secondhandauction.core.auction.exception;
-
-import com.js.secondhandauction.common.exception.ErrorCode;
-
-public class DuplicateUserTickException extends AuctionException {
-    public DuplicateUserTickException() {
-        super(ErrorCode.DUPLICATE_MEMBER_TICK);
-    }
-}

--- a/src/main/java/com/js/secondhandauction/core/auction/exception/NotOverMinBidException.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/exception/NotOverMinBidException.java
@@ -1,9 +1,0 @@
-package com.js.secondhandauction.core.auction.exception;
-
-import com.js.secondhandauction.common.exception.ErrorCode;
-
-public class NotOverMinBidException extends AuctionException {
-    public NotOverMinBidException() {
-        super(ErrorCode.NOT_OVER_MINBID);
-    }
-}

--- a/src/main/java/com/js/secondhandauction/core/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/repository/AuctionRepository.java
@@ -1,7 +1,7 @@
 package com.js.secondhandauction.core.auction.repository;
 
 import com.js.secondhandauction.core.auction.domain.Auction;
-import com.js.secondhandauction.core.item.domain.Item;
+import com.js.secondhandauction.core.auction.dto.AuctionLastBidResponse;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -11,9 +11,11 @@ public interface AuctionRepository {
 
     long create(Auction auction);
 
-    Auction getLastTick(long item_no);
+    AuctionLastBidResponse getLastBid(long item_no);
 
-    int getCountTick(long item_no);
+    int getUserBidCount(long itemNo, long regId);
+
+    int getTotalBidCount(long itemNo);
 
     List<Auction> findByItemNo(long itemNo);
 }

--- a/src/main/java/com/js/secondhandauction/core/auction/service/AuctionFinalizeFailureService.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/service/AuctionFinalizeFailureService.java
@@ -1,0 +1,38 @@
+package com.js.secondhandauction.core.auction.service;
+
+import com.js.secondhandauction.core.auction.dto.AuctionLastBidResponse;
+import com.js.secondhandauction.core.item.domain.Item;
+import com.js.secondhandauction.core.item.domain.State;
+import com.js.secondhandauction.core.item.exception.ItemException;
+import com.js.secondhandauction.core.item.service.ItemService;
+import com.js.secondhandauction.core.member.service.MemberService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class AuctionFinalizeFailureService {
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    ItemService itemService;
+
+    /**
+     * 만료 경매 종료
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = {ItemException.class})
+    public void finishExpiredAuction(Item item, AuctionLastBidResponse lastBid) {
+        if (item.getIsBid()) {
+            memberService.updateMemberTotalBalanceByUserNo(lastBid.getRegId(), lastBid.getBid());
+            itemService.updateItemState(item.getItemNo(), State.SOLDOUT);
+            log.debug("시간 경과로 인한 아이템 " + item.getItem() + "(" + item.getItemNo() + ") 판매완료");
+        } else {
+            itemService.updateItemState(item.getItemNo(), State.UNSOLD);
+            log.debug("시간 경과로 인한 아이템 " + item.getItem() + "(" + item.getItemNo() + ") 유찰");
+        }
+    }
+}

--- a/src/main/java/com/js/secondhandauction/core/auction/service/AuctionService.java
+++ b/src/main/java/com/js/secondhandauction/core/auction/service/AuctionService.java
@@ -83,7 +83,7 @@ public class AuctionService {
     }
 
     private void validateUser(long id, Auction auction) {
-        int userTotalBalance = memberService.getMemberByUniqId(id).getTotalBalance();
+        int userTotalBalance = memberService.getMemberByUserNo(id).getTotalBalance();
         if (userTotalBalance < auction.getBid()) {
             throw new MemberException(ErrorCode.CANNOT_TOTALBALANCE_MINUS);
         }
@@ -136,10 +136,10 @@ public class AuctionService {
 
 
     private void updateUserBalanceAndCreateAuction(Auction auction, Auction lastTick) {
-        memberService.updateMemberTotalBalanceByUniqId(auction.getRegId(), auction.getBid() * -1);
+        memberService.updateMemberTotalBalanceByUserNo(auction.getRegId(), auction.getBid() * -1);
 
         if (lastTick != null) {
-            memberService.updateMemberTotalBalanceByUniqId(lastTick.getRegId(), lastTick.getBid());
+            memberService.updateMemberTotalBalanceByUserNo(lastTick.getRegId(), lastTick.getBid());
         } else {
             itemService.updateItemIsBid(auction.getItemNo(), true);
         }
@@ -152,7 +152,7 @@ public class AuctionService {
     }
 
     private void finishAuction(Auction auction, Item item) {
-        memberService.updateMemberTotalBalanceByUniqId(item.getRegId(), auction.getBid());
+        memberService.updateMemberTotalBalanceByUserNo(item.getRegId(), auction.getBid());
 
         itemService.updateItemState(item.getItemNo(), State.SOLDOUT);
 

--- a/src/main/java/com/js/secondhandauction/core/auth/service/AuthService.java
+++ b/src/main/java/com/js/secondhandauction/core/auth/service/AuthService.java
@@ -1,35 +1,28 @@
 package com.js.secondhandauction.core.auth.service;
 
-import com.js.secondhandauction.common.exception.ErrorCode;
 import com.js.secondhandauction.common.security.service.CustomUserDetails;
-import com.js.secondhandauction.core.member.exception.MemberException;
-import com.js.secondhandauction.core.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AuthService {
     @Autowired
-    MemberRepository memberRepository;
+    AuthenticationProvider AuthenticationProvider;
 
     @Autowired
-    AuthenticationManagerBuilder managerBuilder;
+    UserDetailsService userDetailsService;
 
     public Authentication login(String userId, String password) {
-        CustomUserDetails userDetails = CustomUserDetails.of(memberRepository.findByUserId(userId).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER)));
+        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(userId);
 
         Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, password);
 
-        try {
-            // 인증 정보 반환
-            return managerBuilder.getObject().authenticate(auth);
-        } catch (AuthenticationException e) {
-            throw new MemberException(ErrorCode.INVALID_PASSWORD);
-        }
+        // 인증 정보 반환
+        return AuthenticationProvider.authenticate(auth);
     }
 
 

--- a/src/main/java/com/js/secondhandauction/core/item/controller/ItemController.java
+++ b/src/main/java/com/js/secondhandauction/core/item/controller/ItemController.java
@@ -6,7 +6,6 @@ import com.js.secondhandauction.core.item.domain.Item;
 import com.js.secondhandauction.core.item.dto.ItemRequest;
 import com.js.secondhandauction.core.item.dto.ItemResponse;
 import com.js.secondhandauction.core.item.service.ItemService;
-import com.js.secondhandauction.core.member.domain.Member;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +23,7 @@ public class ItemController {
      */
     @PostMapping
     public ResponseEntity<ApiResponse<ItemResponse>> createItem(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody ItemRequest itemRequest) {
-        final long id = customUserDetails.getId();
-        return new ResponseEntity<>(ApiResponse.success(itemService.createItem(id, itemRequest)), HttpStatus.CREATED);
+        return new ResponseEntity<>(ApiResponse.success(itemService.createItem(customUserDetails, itemRequest)), HttpStatus.CREATED);
     }
 
     /**
@@ -41,8 +39,7 @@ public class ItemController {
      */
     @PutMapping("/{itemNo}")
     public ResponseEntity<ApiResponse<ItemResponse>> updateItem(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable long itemNo, @RequestBody ItemRequest itemRequest) {
-        final long id = customUserDetails.getId();
-        return new ResponseEntity<>(ApiResponse.success(itemService.updateItem(itemNo, id, itemRequest)), HttpStatus.OK);
+        return new ResponseEntity<>(ApiResponse.success(itemService.updateItem(itemNo, customUserDetails, itemRequest)), HttpStatus.OK);
     }
 
     /**
@@ -50,8 +47,7 @@ public class ItemController {
      */
     @DeleteMapping("/{itemNo}")
     public ResponseEntity<ApiResponse<Void>> deleteItem(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable long itemNo) {
-        final long id = customUserDetails.getId();
-        itemService.deleteItem(itemNo, id);
+        itemService.deleteItem(itemNo, customUserDetails);
         return new ResponseEntity<>(ApiResponse.success(null), HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/js/secondhandauction/core/item/domain/Item.java
+++ b/src/main/java/com/js/secondhandauction/core/item/domain/Item.java
@@ -24,6 +24,7 @@ public class Item {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime uptDate;
     private int regPrice;
+    private int immediatePrice;
     private State state;
     private long regId;
     private int betTime;

--- a/src/main/java/com/js/secondhandauction/core/item/dto/ItemRequest.java
+++ b/src/main/java/com/js/secondhandauction/core/item/dto/ItemRequest.java
@@ -6,13 +6,15 @@ import com.js.secondhandauction.core.item.domain.State;
 public record ItemRequest(
         String item,
         String itemDesc,
-        int regPrice
+        int regPrice,
+        int immediatePrice
 ) {
     public Item toEntity() {
         return Item.builder()
                 .item(item)
                 .itemDesc(itemDesc)
                 .regPrice(regPrice)
+                .immediatePrice(immediatePrice)
                 .build();
     }
 

--- a/src/main/java/com/js/secondhandauction/core/item/dto/ItemResponse.java
+++ b/src/main/java/com/js/secondhandauction/core/item/dto/ItemResponse.java
@@ -15,6 +15,7 @@ public class ItemResponse {
     private String item;
     private String itemDesc;
     private int regPrice;
+    private int immediatePrice;
     private State state;
     private Boolean isBid;
 
@@ -24,6 +25,7 @@ public class ItemResponse {
                 .item(item.getItem())
                 .itemDesc(item.getItemDesc())
                 .regPrice(item.getRegPrice())
+                .immediatePrice(item.getImmediatePrice())
                 .state(item.getState())
                 .isBid(item.getIsBid())
                 .build();

--- a/src/main/java/com/js/secondhandauction/core/item/exception/AlreadySoldoutException.java
+++ b/src/main/java/com/js/secondhandauction/core/item/exception/AlreadySoldoutException.java
@@ -1,9 +1,0 @@
-package com.js.secondhandauction.core.item.exception;
-
-import com.js.secondhandauction.common.exception.ErrorCode;
-
-public class AlreadySoldoutException extends ItemException {
-    public AlreadySoldoutException() {
-        super(ErrorCode.ALREADY_SOLDOUT);
-    }
-}

--- a/src/main/java/com/js/secondhandauction/core/item/repository/ItemRepository.java
+++ b/src/main/java/com/js/secondhandauction/core/item/repository/ItemRepository.java
@@ -15,9 +15,7 @@ public interface ItemRepository {
 
     Optional<Item> findByItemNo(long itemNo);
 
-    int updateForOnsale(Item item);
-
-    int updateForUnsold(Item item);
+    int update(Item item);
 
     int updateState(long itemNo, State state);
 

--- a/src/main/java/com/js/secondhandauction/core/item/service/ItemService.java
+++ b/src/main/java/com/js/secondhandauction/core/item/service/ItemService.java
@@ -66,11 +66,11 @@ public class ItemService {
         item.setState(State.ONSALE);
 
         if (getItem.getIsBid() && getItem.getRegPrice() != item.getRegPrice() && getItem.getImmediatePrice() != item.getImmediatePrice()) {
-            throw new ItemException(ErrorCode.CANNOT_CHANGE_BID_ITEM);
+            throw new ItemException(ErrorCode.CANNOT_CHANGE_ITEM);
         }
 
         if (getItem.getState() == State.UNSOLD) {
-            item.setBetTime(makeItemBettime());
+            throw new ItemException(ErrorCode.CANNOT_CHANGE_ITEM);
         }
 
         itemRepository.update(item);
@@ -116,7 +116,7 @@ public class ItemService {
         validateEditableItem(customUserDetails.getId(), item);
 
         if (item.getIsBid() && item.getState() == State.ONSALE) {
-            throw new ItemException(ErrorCode.CANNOT_CHANGE_BID_ITEM);
+            throw new ItemException(ErrorCode.CANNOT_CHANGE_ITEM);
         }
 
         itemRepository.delete(itemNo);
@@ -128,7 +128,7 @@ public class ItemService {
         }
 
         if (item.getState() == State.SOLDOUT) {
-            throw new ItemException(ErrorCode.CANNOT_CHANGE_SOLDOUT_ITEM);
+            throw new ItemException(ErrorCode.CANNOT_CHANGE_ITEM);
         }
 
     }
@@ -140,6 +140,10 @@ public class ItemService {
      */
     private int makeItemBettime() {
         return (int) (Math.random() * 20) + 30;
+    }
+
+    public boolean isItemExpired(Item item) {
+        return item.getRegDate().plusHours(24L * addDay).isBefore(LocalDateTime.now());
     }
 
     @CacheEvict(key = "#itemNo", value = "ITEM_ITEMNO")

--- a/src/main/java/com/js/secondhandauction/core/item/service/ItemService.java
+++ b/src/main/java/com/js/secondhandauction/core/item/service/ItemService.java
@@ -65,7 +65,7 @@ public class ItemService {
         item.setIsBid(getItem.getIsBid());
         item.setState(State.ONSALE);
 
-        if (getItem.getIsBid() && getItem.getRegPrice() != item.getRegPrice()) {
+        if (getItem.getIsBid() && getItem.getRegPrice() != item.getRegPrice() && getItem.getImmediatePrice() != item.getImmediatePrice()) {
             throw new ItemException(ErrorCode.CANNOT_CHANGE_BID_ITEM);
         }
 
@@ -73,7 +73,7 @@ public class ItemService {
             item.setBetTime(makeItemBettime());
         }
 
-        itemRepository.updateForUnsold(item);
+        itemRepository.update(item);
 
         return ItemResponse.of(evictCache(item));
     }

--- a/src/main/java/com/js/secondhandauction/core/member/domain/Member.java
+++ b/src/main/java/com/js/secondhandauction/core/member/domain/Member.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
-    private long uniqId;
+    private long userNo;
     private String userId;
     private String password;
     private String nickname;

--- a/src/main/java/com/js/secondhandauction/core/member/dto/MemberGetResponse.java
+++ b/src/main/java/com/js/secondhandauction/core/member/dto/MemberGetResponse.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberGetResponse implements Serializable {
-    private long uniqId;
+    private long userNo;
     private String userId;
     private String nickname;
     private int totalBalance;
@@ -32,7 +32,7 @@ public class MemberGetResponse implements Serializable {
 
     public static MemberGetResponse of(Member member) {
         return MemberGetResponse.builder()
-                .uniqId(member.getUniqId())
+                .userNo(member.getUserNo())
                 .userId(member.getUserId())
                 .nickname(member.getNickname())
                 .totalBalance(member.getTotalBalance())

--- a/src/main/java/com/js/secondhandauction/core/member/repository/MemberRepository.java
+++ b/src/main/java/com/js/secondhandauction/core/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ public interface MemberRepository {
 
     Optional<Member> findByUserId(String userId);
 
-    Optional<Member> findByUniqId(long id);
+    Optional<Member> findByUserNo(long id);
 
     void updateTotalBalance(String userId, int totalBalance);
 

--- a/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
+++ b/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
@@ -64,6 +64,14 @@ public class MemberService {
         return MemberGetResponse.of(member);
     }
 
+    /**
+     * 로그인을 위한 회원 조회 userid 로
+     */
+    @Cacheable(key = "#userId", value = "MEMBER_LOGIN")
+    public Member getMemberForLogin(String userId) {
+        return memberRepository.findByUserId(userId).orElseThrow(NotFoundMemberException::new);
+    }
+
 
     /**
      * 회원 가진금액 더하기 UserId 로

--- a/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
+++ b/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
@@ -56,11 +56,11 @@ public class MemberService {
     }
 
     /**
-     * 회원 조회 uniqid로
+     * 회원 조회 userNo로
      */
-    @Cacheable(key = "#id", value = "MEMBER_UNIQID")
-    public MemberGetResponse getMemberByUniqId(long id) {
-        Member member = memberRepository.findByUniqId(id).orElseThrow(NotFoundMemberException::new);
+    @Cacheable(key = "#id", value = "MEMBER_USERNO")
+    public MemberGetResponse getMemberByUserNo(long id) {
+        Member member = memberRepository.findByUserNo(id).orElseThrow(NotFoundMemberException::new);
         return MemberGetResponse.of(member);
     }
 
@@ -81,10 +81,10 @@ public class MemberService {
     }
 
     /**
-     * 회원 가진금액 더하기 uniqId로
+     * 회원 가진금액 더하기 userNo로
      */
-    public void updateMemberTotalBalanceByUniqId(long id, int totalBalance) {
-        Member member = memberRepository.findByUniqId(id).orElseThrow(NotFoundMemberException::new);
+    public void updateMemberTotalBalanceByUserNo(long id, int totalBalance) {
+        Member member = memberRepository.findByUserNo(id).orElseThrow(NotFoundMemberException::new);
 
         evictCache(member);
 
@@ -131,7 +131,7 @@ public class MemberService {
     @Caching(
             evict = {
                     @CacheEvict(key = "#member.userId", value = "MEMBER_USERID"),
-                    @CacheEvict(key = "#member.uniqId", value = "MEMBER_UNIQID")
+                    @CacheEvict(key = "#member.userNo", value = "MEMBER_USERNO")
             }
     )
     public void evictCache(Member member) {

--- a/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
+++ b/src/main/java/com/js/secondhandauction/core/member/service/MemberService.java
@@ -8,8 +8,8 @@ import com.js.secondhandauction.core.member.dto.MemberGetResponse;
 import com.js.secondhandauction.core.member.exception.NotFoundMemberException;
 import com.js.secondhandauction.core.member.exception.MemberException;
 import com.js.secondhandauction.core.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
@@ -17,13 +17,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class MemberService {
 
-    final MemberRepository memberRepository;
+    @Autowired
+    MemberRepository memberRepository;
 
-    final PasswordEncoder passwordEncoder;
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     /**
      * 회원가입

--- a/src/main/resources/mybatis-mapper/AuctionMapper.xml
+++ b/src/main/resources/mybatis-mapper/AuctionMapper.xml
@@ -13,7 +13,7 @@
         ]]>
     </insert>
 
-    <select id="getLastTick">
+    <select id="getLastBid">
     <![CDATA[
         SELECT item_no,
                bid,
@@ -24,9 +24,18 @@
         ]]>
     </select>
 
-    <select id="getCountTick">
+    <select id="getUserBidCount">
         <![CDATA[
         select count(*)
+        from Auction
+        where item_no = #{itemNo}
+          and reg_id = #{regId}
+        ]]>
+    </select>
+
+    <select id="getTotalBidCount">
+        <![CDATA[
+        select count(*) as totalBidCount
         from Auction
         where item_no = #{itemNo}
         ]]>

--- a/src/main/resources/mybatis-mapper/ItemMapper.xml
+++ b/src/main/resources/mybatis-mapper/ItemMapper.xml
@@ -8,8 +8,8 @@
             keyProperty="itemNo"
             keyColumn="item_no">
         insert into Item
-            (item, item_desc, reg_price, state, reg_id, bet_time)
-        values (#{item}, #{itemDesc}, #{regPrice}, #{state}, #{regId}, #{betTime})
+            (item, item_desc, reg_price, immediate_price, state, reg_id, bet_time)
+        values (#{item}, #{itemDesc}, #{regPrice}, #{immediatePrice}, #{state}, #{regId}, #{betTime})
     </insert>
 
     <select id="findByItemNo" resultType="com.js.secondhandauction.core.item.domain.Item">
@@ -20,6 +20,7 @@
                reg_date,
                upt_date,
                reg_price,
+               immediate_price,
                state,
                reg_id,
                bet_time,
@@ -30,27 +31,16 @@
         ]]>
     </select>
 
-    <update id="updateForUnsold" parameterType="com.js.secondhandauction.core.item.domain.Item">
+    <update id="update" parameterType="com.js.secondhandauction.core.item.domain.Item">
     <![CDATA[
         update
             Item
-        set item      = #{item}
-          , item_desc = #{itemDesc}
-          , reg_price = #{regPrice}
-          , state     = #{state}
-          , bet_time  = #{betTime}
-        where item_no = #{itemNo}
-          and is_del = 0
-        ]]>
-    </update>
-
-    <update id="updateForOnsale" parameterType="com.js.secondhandauction.core.item.domain.Item">
-    <![CDATA[
-        update
-            Item
-        set item      = #{item}
-          , item_desc = #{itemDesc}
-          , reg_price = #{regPrice}
+        set item            = #{item}
+          , item_desc       = #{itemDesc}
+          , reg_price       = #{regPrice}
+          , immediate_price = #{immediatePrice}
+          , state           = #{state}
+          , bet_time        = #{betTime}
         where item_no = #{itemNo}
           and is_del = 0
         ]]>

--- a/src/main/resources/mybatis-mapper/UserMapper.xml
+++ b/src/main/resources/mybatis-mapper/UserMapper.xml
@@ -5,17 +5,17 @@
 
 <mapper namespace="com.js.secondhandauction.core.member.repository.MemberRepository">
     <insert id="create" parameterType="com.js.secondhandauction.core.member.domain.Member" useGeneratedKeys="true"
-            keyProperty="uniqId" keyColumn="uniqId">
+            keyProperty="userNo" keyColumn="userNo">
     <![CDATA[
         insert into Member
-            (uniq_id, user_id, nickname, password, total_balance, role)
-        values (#{uniqId}, #{userId}, #{nickname}, #{password}, #{totalBalance}, #{role})
+            (user_id, nickname, password, total_balance, role)
+        values (#{userId}, #{nickname}, #{password}, #{totalBalance}, #{role})
         ]]>
     </insert>
 
     <select id="findByUserId">
     <![CDATA[
-        select uniq_id,
+        select user_no,
                user_id,
                password,
                nickname,
@@ -28,9 +28,9 @@
         ]]>
     </select>
 
-    <select id="findByUniqId">
+    <select id="findByUserNo">
     <![CDATA[
-        select uniq_id,
+        select user_no,
                user_id,
                password,
                nickname,
@@ -39,7 +39,7 @@
                upt_date,
                role
         from Member
-        where uniq_id = #{uniqId}
+        where user_no = #{userNo}
         ]]>
     </select>
 

--- a/src/test/java/com/js/secondhandauction/core/auction/AuctionServiceTest.java
+++ b/src/test/java/com/js/secondhandauction/core/auction/AuctionServiceTest.java
@@ -1,19 +1,21 @@
 package com.js.secondhandauction.core.auction;
 
-import com.js.secondhandauction.core.auction.domain.Auction;
+import com.js.secondhandauction.common.exception.ErrorCode;
+import com.js.secondhandauction.common.security.service.CustomUserDetails;
 import com.js.secondhandauction.core.auction.dto.AuctionRequest;
 import com.js.secondhandauction.core.auction.dto.AuctionResponse;
-import com.js.secondhandauction.core.auction.exception.DuplicateUserTickException;
-import com.js.secondhandauction.core.auction.exception.NotOverMinBidException;
+import com.js.secondhandauction.core.auction.dto.AuctionLastBidResponse;
+import com.js.secondhandauction.core.auction.exception.AuctionException;
 import com.js.secondhandauction.core.auction.repository.AuctionRepository;
+import com.js.secondhandauction.core.auction.service.AuctionFinalizeFailureService;
 import com.js.secondhandauction.core.auction.service.AuctionService;
 import com.js.secondhandauction.core.item.domain.Item;
 import com.js.secondhandauction.core.item.domain.State;
-import com.js.secondhandauction.core.item.exception.AlreadySoldoutException;
+import com.js.secondhandauction.core.item.exception.ItemException;
 import com.js.secondhandauction.core.item.service.ItemService;
-import com.js.secondhandauction.core.member.domain.Member;
-import com.js.secondhandauction.core.member.dto.MemberGetResponse;
+import com.js.secondhandauction.core.item.util.TestItemBuilder;
 import com.js.secondhandauction.core.member.service.MemberService;
+import com.js.secondhandauction.core.member.util.TestMemberBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,63 +41,71 @@ public class AuctionServiceTest {
     private ItemService itemService;
     @Mock
     private MemberService memberService;
-    private final long ITEM_REG_ID = 100L;
-    private final long MEMBER_ID = 1L;
-    private final long MEMBER_ID2 = 2L;
-    private final long NO_TICK_ITEM_NO = 2L;
-    private final long TICK_ITEM_NO = 3L;
-    private final long SOLDOUT_ITEM_NO = 4L;
+    @Mock
+    private AuctionFinalizeFailureService auctionFinalizeFailureService;
+
+    private final long USER_NO = 1L;
+    private final long USER_NO2 = 2L;
+    private final long NO_BID_ITEM_NO = 2L;
+    private final long BID_ITEM_NO = 3L;
+    private final long END_BID_ITEM_NO = 4L;
+    private final long SOLDOUT_ITEM_NO = 5L;
+    private final long EXPIRED_ITEM_NO = 6L;
     private AuctionRequest auctionRequest;
-    private MemberGetResponse member;
-    private MemberGetResponse member2;
-    private Item NO_TICK_ITEM;
-    private Item TICK_ITEM;
+    private CustomUserDetails USERDETAILS_USER_NO;
+    private CustomUserDetails USERDETAILS_USER_NO2;
+    private CustomUserDetails USERDETAILS_REG_USER_NO;
+    private Item NO_BID_ITEM;
+    private Item BID_ITEM;
+    private Item END_BID_ITEM;
     private Item SOLDOUT_ITEM;
+    private Item EXPIRED_ITEM;
+    private AuctionLastBidResponse BID_ITEM_RESPONSE;
+    private AuctionLastBidResponse END_BID_ITEM_RESPONSE;
+    private AuctionLastBidResponse SOLDOUT_ITEM_RESPONSE;
 
 
     @BeforeEach
     public void setup() {
-        member = MemberGetResponse.builder()
-                .userNo(MEMBER_ID)
-                .userId("Test User")
-                .nickname("Test Name")
-                .totalBalance(10000000)
+        USERDETAILS_USER_NO = TestMemberBuilder.buildUserDetails(USER_NO);
+
+        USERDETAILS_USER_NO2 = TestMemberBuilder.buildUserDetails(USER_NO2);
+
+        USERDETAILS_REG_USER_NO = TestMemberBuilder.buildUserDetails(TestItemBuilder.getRegUserNo());
+
+        NO_BID_ITEM = TestItemBuilder.buildItem(NO_BID_ITEM_NO, State.ONSALE, false);
+
+        BID_ITEM = TestItemBuilder.buildItem(BID_ITEM_NO, State.ONSALE, true);
+
+        END_BID_ITEM = TestItemBuilder.buildItem(END_BID_ITEM_NO, State.ONSALE, true);
+
+        SOLDOUT_ITEM = TestItemBuilder.buildItem(SOLDOUT_ITEM_NO, State.SOLDOUT, true);
+
+        EXPIRED_ITEM = TestItemBuilder.buildItem(EXPIRED_ITEM_NO, State.ONSALE, true);
+
+        BID_ITEM_RESPONSE = AuctionLastBidResponse.builder()
+                .bid(350000)
+                .regId(USER_NO)
+                .itemNo(BID_ITEM_NO)
                 .build();
 
-        member2 = MemberGetResponse.builder()
-                .userNo(MEMBER_ID2)
-                .userId("Test User")
-                .nickname("Test Name")
-                .totalBalance(10000000)
+        END_BID_ITEM_RESPONSE = AuctionLastBidResponse.builder()
+                .bid(350000)
+                .regId(USER_NO)
+                .itemNo(END_BID_ITEM_NO)
                 .build();
 
-        NO_TICK_ITEM = Item.builder()
-                .itemNo(ITEM_REG_ID)
-                .item("Test Item")
-                .state(State.ONSALE)
-                .betTime(5)
-                .regPrice(300000)
+        SOLDOUT_ITEM_RESPONSE = AuctionLastBidResponse.builder()
+                .bid(350000)
+                .regId(USER_NO)
+                .itemNo(SOLDOUT_ITEM_NO)
                 .build();
 
-        TICK_ITEM = Item.builder()
-                .itemNo(ITEM_REG_ID)
-                .item("Test Item")
-                .state(State.ONSALE)
-                .betTime(5)
-                .regPrice(300000)
-                .build();
-
-        SOLDOUT_ITEM = Item.builder()
-                .itemNo(ITEM_REG_ID)
-                .item("Test Item")
-                .state(State.SOLDOUT)
-                .betTime(5)
-                .regPrice(300000)
-                .build();
-
-        Mockito.when(itemService.getItem(NO_TICK_ITEM_NO)).thenReturn(NO_TICK_ITEM);
-        Mockito.when(itemService.getItem(TICK_ITEM_NO)).thenReturn(TICK_ITEM);
+        Mockito.when(itemService.getItem(NO_BID_ITEM_NO)).thenReturn(NO_BID_ITEM);
+        Mockito.when(itemService.getItem(BID_ITEM_NO)).thenReturn(BID_ITEM);
+        Mockito.when(itemService.getItem(END_BID_ITEM_NO)).thenReturn(END_BID_ITEM);
         Mockito.when(itemService.getItem(SOLDOUT_ITEM_NO)).thenReturn(SOLDOUT_ITEM);
+        Mockito.when(itemService.getItem(EXPIRED_ITEM_NO)).thenReturn(EXPIRED_ITEM);
 
     }
 
@@ -103,46 +113,58 @@ public class AuctionServiceTest {
     @DisplayName("경매를 생성한다")
     void testCreateAuction() {
 
-        auctionRequest = new AuctionRequest(NO_TICK_ITEM_NO, 500000);
-
-        Mockito.when(memberService.getMemberByUserNo(MEMBER_ID)).thenReturn(member);
-
-        Mockito.when(memberService.getMemberByUserNo(MEMBER_ID2)).thenReturn(member2);
+        auctionRequest = new AuctionRequest(NO_BID_ITEM_NO, 500000);
 
         //정상 입찰
-        Mockito.when(auctionRepository.getCountTick(NO_TICK_ITEM_NO)).thenReturn(0);
+        Mockito.when(auctionRepository.getTotalBidCount(NO_BID_ITEM_NO)).thenReturn(0);
 
-        AuctionResponse createdAuction = auctionService.createAuction(MEMBER_ID, auctionRequest);
+        AuctionResponse createdAuction = auctionService.createAuction(USERDETAILS_USER_NO, auctionRequest);
         assertNotNull(createdAuction);
         assertThat(createdAuction.getBid()).isEqualTo(500000);
 
-        AuctionRequest soldAuctionRequest = new AuctionRequest(SOLDOUT_ITEM_NO, 500000);
+        //아이템 만료로 입찰 실패
+        AuctionRequest expiredAuctionRequest = new AuctionRequest(EXPIRED_ITEM_NO, 500000);
+
+        Mockito.when(itemService.isItemExpired(EXPIRED_ITEM)).thenReturn(true);
+
+        Assertions.assertThrows(ItemException.class,
+                () -> auctionService.createAuction(USERDETAILS_USER_NO, expiredAuctionRequest), ErrorCode.CANNOT_BID_EXPIRED.getMessage());
+
+
+        //아이템 등록자 입찰로 입찰실패
+        AuctionRequest regAuctionRequest = new AuctionRequest(NO_BID_ITEM_NO, 500000);
+
+        Assertions.assertThrows(AuctionException.class,
+                () -> auctionService.createAuction(USERDETAILS_REG_USER_NO, regAuctionRequest), ErrorCode.CANNOT_BID_MYSELF.getMessage());
+
+        //입찰 횟수 초과로 입찰 실패
+        AuctionRequest endAuctionRequest = new AuctionRequest(END_BID_ITEM_NO, 500000);
+
+        Mockito.when(auctionRepository.getLastBid(END_BID_ITEM_NO)).thenReturn(END_BID_ITEM_RESPONSE);
+
+        Assertions.assertThrows(AuctionException.class,
+                () -> auctionService.createAuction(USERDETAILS_USER_NO, endAuctionRequest), ErrorCode.CANNOT_BETTING_OVER_MAXTIMES.getMessage());
 
         //판매 된 물건 입찰 실패
-        Assertions.assertThrows(AlreadySoldoutException.class,
-                () -> auctionService.createAuction(MEMBER_ID, soldAuctionRequest));
+        AuctionRequest soldAuctionRequest = new AuctionRequest(SOLDOUT_ITEM_NO, 500000);
+
+        Assertions.assertThrows(ItemException.class,
+                () -> auctionService.createAuction(USERDETAILS_USER_NO, soldAuctionRequest), ErrorCode.CAN_BID_ONLY_ONSALE.getMessage());
 
         //중복 입찰 실패
-        Mockito.when(auctionRepository.getCountTick(TICK_ITEM_NO)).thenReturn(1);
+        Mockito.when(auctionRepository.getLastBid(BID_ITEM_NO)).thenReturn(BID_ITEM_RESPONSE);
 
-        Auction lastTick = Auction.builder()
-                .bid(400000)
-                .regId(MEMBER_ID)
-                .itemNo(TICK_ITEM_NO)
-                .build();
+        AuctionRequest dupAuctionRequest = new AuctionRequest(BID_ITEM_NO, 500000);
 
-        Mockito.when(auctionRepository.getLastTick(TICK_ITEM_NO)).thenReturn(lastTick);
-
-        AuctionRequest dupAuctionRequest = new AuctionRequest(TICK_ITEM_NO, 500000);
-
-        Assertions.assertThrows(DuplicateUserTickException.class,
-                () -> auctionService.createAuction(MEMBER_ID, dupAuctionRequest));
+        Assertions.assertThrows(AuctionException.class,
+                () -> auctionService.createAuction(USERDETAILS_USER_NO, dupAuctionRequest), ErrorCode.DUPLICATE_MEMBER_TICK.getMessage());
 
         //최소 베팅 금액
-        AuctionRequest newAuctionRequest = new AuctionRequest(TICK_ITEM_NO, 410000);
+        AuctionRequest newAuctionRequest = new AuctionRequest(BID_ITEM_NO, 360000);
 
-        Assertions.assertThrows(NotOverMinBidException.class,
-                () -> auctionService.createAuction(MEMBER_ID2, newAuctionRequest));
+        Assertions.assertThrows(AuctionException.class,
+                () -> auctionService.createAuction(USERDETAILS_USER_NO2, newAuctionRequest), ErrorCode.NOT_OVER_MINBID.getMessage());
+
     }
 
 }

--- a/src/test/java/com/js/secondhandauction/core/auction/AuctionServiceTest.java
+++ b/src/test/java/com/js/secondhandauction/core/auction/AuctionServiceTest.java
@@ -56,14 +56,14 @@ public class AuctionServiceTest {
     @BeforeEach
     public void setup() {
         member = MemberGetResponse.builder()
-                .uniqId(MEMBER_ID)
+                .userNo(MEMBER_ID)
                 .userId("Test User")
                 .nickname("Test Name")
                 .totalBalance(10000000)
                 .build();
 
         member2 = MemberGetResponse.builder()
-                .uniqId(MEMBER_ID2)
+                .userNo(MEMBER_ID2)
                 .userId("Test User")
                 .nickname("Test Name")
                 .totalBalance(10000000)
@@ -105,9 +105,9 @@ public class AuctionServiceTest {
 
         auctionRequest = new AuctionRequest(NO_TICK_ITEM_NO, 500000);
 
-        Mockito.when(memberService.getMemberByUniqId(MEMBER_ID)).thenReturn(member);
+        Mockito.when(memberService.getMemberByUserNo(MEMBER_ID)).thenReturn(member);
 
-        Mockito.when(memberService.getMemberByUniqId(MEMBER_ID2)).thenReturn(member2);
+        Mockito.when(memberService.getMemberByUserNo(MEMBER_ID2)).thenReturn(member2);
 
         //정상 입찰
         Mockito.when(auctionRepository.getCountTick(NO_TICK_ITEM_NO)).thenReturn(0);

--- a/src/test/java/com/js/secondhandauction/core/item/ItemServiceTest.java
+++ b/src/test/java/com/js/secondhandauction/core/item/ItemServiceTest.java
@@ -68,12 +68,13 @@ public class ItemServiceTest {
 
     @BeforeEach
     void setup() {
-        itemRequest = new ItemRequest("Test Item", "", 200000);
+        itemRequest = new ItemRequest("Test Item", "", 200000, 100000);
 
         onsaleItem = Item.builder()
                 .itemNo(ONSALE_ITEM_NO)
                 .item("Test Item")
                 .regPrice(200000)
+                .immediatePrice(1000000)
                 .regId(USER_NO)
                 .state(State.ONSALE)
                 .betTime(10)
@@ -84,6 +85,7 @@ public class ItemServiceTest {
                 .itemNo(ONSALE_ITEM_NO)
                 .item("Test Item")
                 .regPrice(300000)
+                .immediatePrice(1000000)
                 .regId(USER_NO)
                 .state(State.ONSALE)
                 .betTime(10)
@@ -94,6 +96,7 @@ public class ItemServiceTest {
                 .itemNo(ONSALE_ITEM_NO)
                 .item("Test Item")
                 .regPrice(200000)
+                .immediatePrice(1000000)
                 .regId(USER_NO)
                 .state(State.SOLDOUT)
                 .betTime(10)
@@ -104,6 +107,7 @@ public class ItemServiceTest {
                 .itemNo(ONSALE_ITEM_NO)
                 .item("Test Item")
                 .regPrice(200000)
+                .immediatePrice(1000000)
                 .regId(USER_NO)
                 .state(State.UNSOLD)
                 .betTime(10)
@@ -167,15 +171,16 @@ public class ItemServiceTest {
         itemService.updateItem(ONSALE_ITEM_NO, userDetails, itemRequest);
 
         // 상품 수정
-        itemService.updateItem(UNSOLD_ITEM_NO, userDetails, itemRequest);
+        assertThrows(ItemException.class,
+                () -> itemService.updateItem(UNSOLD_ITEM_NO, userDetails, itemRequest), ErrorCode.CANNOT_CHANGE_ITEM.getMessage());
 
         //입찰이 이미 시작된 아이템의 가격은 수정할 수 없다.
         assertThrows(ItemException.class,
-                () -> itemService.updateItem(ONSALE_IS_BID_ITEM_NO, userDetails, itemRequest), ErrorCode.CANNOT_CHANGE_BID_ITEM.getMessage());
+                () -> itemService.updateItem(ONSALE_IS_BID_ITEM_NO, userDetails, itemRequest), ErrorCode.CANNOT_CHANGE_ITEM.getMessage());
 
         //판매 완료된 아이템은 수정할 수 없다.
         assertThrows(ItemException.class,
-                () -> itemService.updateItem(SOLDOUT_ITEM_NO, userDetails, itemRequest), ErrorCode.CANNOT_CHANGE_SOLDOUT_ITEM.getMessage());
+                () -> itemService.updateItem(SOLDOUT_ITEM_NO, userDetails, itemRequest), ErrorCode.CANNOT_CHANGE_ITEM.getMessage());
 
     }
 
@@ -199,11 +204,11 @@ public class ItemServiceTest {
 
         //입찰이 이미 시작된 아이템은 삭제할 수 없다.
         assertThrows(ItemException.class,
-                () -> itemService.deleteItem(ONSALE_IS_BID_ITEM_NO, userDetails), ErrorCode.CANNOT_CHANGE_BID_ITEM.getMessage());
+                () -> itemService.deleteItem(ONSALE_IS_BID_ITEM_NO, userDetails), ErrorCode.CANNOT_CHANGE_ITEM.getMessage());
 
         //판매 완료된 아이템은 삭제할 수 없다.
         assertThrows(ItemException.class,
-                () -> itemService.deleteItem(SOLDOUT_ITEM_NO, userDetails), ErrorCode.CANNOT_CHANGE_SOLDOUT_ITEM.getMessage());
+                () -> itemService.deleteItem(SOLDOUT_ITEM_NO, userDetails), ErrorCode.CANNOT_CHANGE_ITEM.getMessage());
     }
 
 }

--- a/src/test/java/com/js/secondhandauction/core/item/util/TestItemBuilder.java
+++ b/src/test/java/com/js/secondhandauction/core/item/util/TestItemBuilder.java
@@ -1,0 +1,30 @@
+package com.js.secondhandauction.core.item.util;
+
+import com.js.secondhandauction.core.item.domain.Item;
+import com.js.secondhandauction.core.item.domain.State;
+
+import java.time.LocalDateTime;
+
+public class TestItemBuilder {
+    static long REG_USER_NO = 100L;
+
+    public static Item buildItem(long itemNo, State state, Boolean isBid) {
+        return Item.builder()
+                .itemNo(itemNo)
+                .item("item")
+                .itemDesc("itemDesc")
+                .regDate(LocalDateTime.now())
+                .uptDate(LocalDateTime.now())
+                .regPrice(300000)
+                .immediatePrice(2000000)
+                .state(state)
+                .regId(REG_USER_NO)
+                .betTime(30)
+                .isBid(isBid)
+                .build();
+    }
+
+    public static long getRegUserNo() {
+        return REG_USER_NO;
+    }
+}

--- a/src/test/java/com/js/secondhandauction/core/member/MemberServiceTest.java
+++ b/src/test/java/com/js/secondhandauction/core/member/MemberServiceTest.java
@@ -105,17 +105,17 @@ public class MemberServiceTest {
     @DisplayName("유저의 자금을 변경한다")
     void testUpdateTotalBalance() {
         //정상 자금 변경
-        when(memberRepository.findByUniqId(10L)).thenReturn(Optional.ofNullable(member));
+        when(memberRepository.findByUserNo(10L)).thenReturn(Optional.ofNullable(member));
 
-        memberService.updateMemberTotalBalanceByUniqId(10L, 500000);
+        memberService.updateMemberTotalBalanceByUserNo(10L, 500000);
 
         Mockito.verify(memberRepository, times(1)).updateTotalBalance(anyString(), anyInt());
 
         //사용자 자금보다 더 큰 금액을 빼려 해 변경에 실패
-        when(memberRepository.findByUniqId(10L)).thenReturn(Optional.ofNullable(member));
+        when(memberRepository.findByUserNo(10L)).thenReturn(Optional.ofNullable(member));
 
         assertThrows(MemberException.class,
-                () -> memberService.updateMemberTotalBalanceByUniqId(10L, -20000000), ErrorCode.CANNOT_TOTALBALANCE_MINUS.getMessage());
+                () -> memberService.updateMemberTotalBalanceByUserNo(10L, -20000000), ErrorCode.CANNOT_TOTALBALANCE_MINUS.getMessage());
 
     }
 

--- a/src/test/java/com/js/secondhandauction/core/member/util/TestMemberBuilder.java
+++ b/src/test/java/com/js/secondhandauction/core/member/util/TestMemberBuilder.java
@@ -1,0 +1,14 @@
+package com.js.secondhandauction.core.member.util;
+
+import com.js.secondhandauction.common.security.service.CustomUserDetails;
+import com.js.secondhandauction.core.member.domain.Role;
+
+public class TestMemberBuilder {
+    public static CustomUserDetails buildUserDetails(long userNo) {
+        return CustomUserDetails.builder()
+                .userNo(userNo)
+                .userId("userId")
+                .role(Role.USER)
+                .build();
+    }
+}


### PR DESCRIPTION
ItemService isEditable / 함수 validate 형식으로 함수 명 및 역할 개선
Item /에 즉시구매가 immediate_price 추가
Item / 만료여부 확인 추가, 유찰된 아이템 수정할 수 없도록 변경
Auction /한 사람이 한 경매에 5번만 제한 추가
Auction /아이템 등록자 경매 참여 불가능하도록 추가
Auction /아이템 경매시간 초과 시 경매 종료 추가
Auction /즉시구매가 이상 베팅 실패 추가
Auction /즉시구매 기능 추가
Auction /Test case 단순화를 위한 Builder 추가